### PR TITLE
added rejectUnauthorized to https request options

### DIFF
--- a/utils/ChromiumDownloader.js
+++ b/utils/ChromiumDownloader.js
@@ -236,8 +236,8 @@ function requestOptions(url, method = 'GET') {
     /** @type {Object} */
     const parsedProxyURL = URL.parse(proxyURL);
     parsedProxyURL.secureProxy = parsedProxyURL.protocol === 'https:';
-
     result.agent = new ProxyAgent(parsedProxyURL);
+    result.rejectUnauthorized = false;
   }
 
   return result;


### PR DESCRIPTION
Currently behind my proxy `curl` works but this script will not.

Some context here:
https://stackoverflow.com/questions/47589195/unable-to-make-proxy-request-with-https-module

1. Kept getting `407 Proxy Authentication Required`
2. With proxy creds getting `unable to get local issuer certificate`